### PR TITLE
Fix broken init script

### DIFF
--- a/root/init
+++ b/root/init
@@ -21,7 +21,7 @@ mkdir -p \
     /transcode
 
 # 修改用户的主组：如果 PGID 对应的组不存在，则修改；如果存在，将用户加入该组
-if [ ! getent group "$PGID" >/dev/null ] ; then
+if ! $(getent group "$PGID" >/dev/null) ; then
     echo "Changing jellyfin group GID from $(getent group jellyfin | cut -d: -f3) to $PGID"
     groupmod -g "$PGID" jellyfin
 else


### PR DESCRIPTION
The comparison on line 24 is broken. This would never be noticed unless the intent was to use a UID/GID different from 1000.

Using `[ ]` is a test. It has to compare values. You cannot pass a command within it. You can test this yourself in the container by running `sh -x init` on the terminal.

```
$ docker run --rm -it --entrypoint sh clion007/jellyfin
/ #
/ # sh -x init
+ sh -x init
+ set -e
+ DEFAULT_PUID=1000
+ DEFAULT_PGID=1000
+ PUID=1000
+ PGID=1000
+ echo 'Starting with PUID=1000, PGID=1000'
Starting with PUID=1000, PGID=1000
+ mkdir -p /config/log /config/data/plugins/configurations /config/data/transcodes /config/cache /data /transcode
+ '[' '!' getent group 1000 ]
sh: group: unknown operand <--- broken
+ getent group 1000
+ cut -d: -f1
+ existing_group=jellyfin
+ usermod -g jellyfin jellyfin
usermod: no changes
+ id -u jellyfin
+ '[' 1000 '!=' 1000 ]
+ chown -R 1000:1000 /config /transcode
+ chmod -R 755 /config
+ chmod 775 /config/data/transcodes
+ '['  '!='  ]
+ id -u
+ '['  '=' jellyfin -a 0 '=' 0 ]
+ exec
```
After changing `init` line 24 to this, it works as expected.

```
/ # sh -x init
+ sh -x init
+ set -e
+ DEFAULT_PUID=1000
+ DEFAULT_PGID=1000
+ PUID=1000
+ PGID=1000
+ echo 'Starting with PUID=1000, PGID=1000'
Starting with PUID=1000, PGID=1000
+ mkdir -p /config/log /config/data/plugins/configurations /config/data/transcodes /config/cache /data /transcode
+ getent group 1000
+
+ getent group 1000
+ cut -d: -f1
+ existing_group=jellyfin
+ usermod -g jellyfin jellyfin
usermod: no changes
+ id -u jellyfin
+ '[' 1000 '!=' 1000 ]
+ chown -R 1000:1000 /config /transcode
+ chmod -R 755 /config
+ chmod 775 /config/data/transcodes
+ '['  '!='  ]
+ id -u
+ '['  '=' jellyfin -a 0 '=' 0 ]
+ exec
```